### PR TITLE
Updated the aws-sdk version to a latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "homepage": "https://github.com/signalfx/s3-server",
   "dependencies": {
+    "aws-sdk": "^2.990.0",
     "express": "^4.10.2",
     "minimist": "^1.1.0",
-    "aws-sdk": "^2.0.31",
     "mustache": "^0.8.2"
   }
 }


### PR DESCRIPTION
The aws-sdk version needs to be updated to satisfy the EKS minimum requirements.
https://signalfuse.atlassian.net/wiki/spaces/INFRA/pages/2226913331/Migrate+Services+from+Maestro+to+Kubernetes+EKS#Requirements-for-Applications-to-be-able-to-use-AWS-IRSA

version 2.162.0 does not support webidentity and that's the reason the previewserver throws errors:
Serving private-sites--signalfx-com on port 3010
{ [AccessDenied: Access Denied]
  message: 'Access Denied',
  code: 'AccessDenied',
  region: 'us-east-1',
  time: Thu Sep 16 2021 00:28:42 GMT+0000 (UTC),
  requestId: '1SWJHZXKZX6Z8KV4',
  extendedRequestId: 'KsmfrB/lkZZcqUYrhUfP3ddjJvFPb2RdzitFJ0bhtQkWwYhgsbBr9jTqheVNxGfQsNn2vs1basU=',
  cfId: undefined,
  statusCode: 403,
  retryable: false,
  retryDelay: 17.60030679870397 }
/opt/s3-server/node_modules/aws-sdk/lib/request.js:31